### PR TITLE
Proxy tensor from extension

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -41,6 +41,7 @@ cc_library(
         "@libtorch//:include/torch/csrc/api/include",
     ],
 	features = ["cpp17"],
+	linkopts = ["-luuid"],
 )
 
 cc_library(

--- a/csrc/python_bindings.cc
+++ b/csrc/python_bindings.cc
@@ -34,4 +34,6 @@ PYBIND11_MODULE(remote_cuda_ext, m) {
 				"Register remote CUDA device type with PyTorch");
 		m.def("register_dispatch_keys", &remote_cuda::register_dispatch_keys,
 				"Register dispatcher keys for remote operations");
+		m.def("get_registered_remote_id", &remote_cuda::get_registered_remote_id,
+				"Get the registered remote ID for a tensor");
 }

--- a/csrc/remote_dispatch.h
+++ b/csrc/remote_dispatch.h
@@ -18,6 +18,7 @@ namespace remote_cuda {
 constexpr c10::DispatchKey REMOTE_CUDA_KEY = c10::DispatchKey::PrivateUse1;
 
 void register_dispatch_keys();
+std::string get_registered_remote_id(const at::Tensor& t);
 
 // Handle specific operation types
 at::Tensor handle_empty_strided(c10::IntArrayRef size, 

--- a/remote_cuda/__init__.py
+++ b/remote_cuda/__init__.py
@@ -144,9 +144,6 @@ if hasattr(torch.ops, 'load_library'):
 #_ext.register_device()
 #_ext.register_dispatch_keys()
 
-# Import core symbols
-from .remote_tensor import RemoteProxyTensor
-
 # Expose remote_cuda for tests and modules
 remote_cuda = torch.remote_cuda
 

--- a/remote_cuda/remote_tensor.py
+++ b/remote_cuda/remote_tensor.py
@@ -1,0 +1,84 @@
+import torch
+import uuid
+import weakref
+
+# REMOTE_CUDA = torch.device("privateuseone")
+
+# Global registry of remote tensors
+_remote_tensor_registry = weakref.WeakValueDictionary()
+
+
+class RemoteProxyTensor(torch.Tensor):
+    """A proxy tensor that represents a tensor on a remote device."""
+    
+    @staticmethod
+    def __new__(cls, base_tensor, remote_id=None):
+        instance = torch.Tensor._make_subclass(cls, base_tensor)
+        if remote_id is None:
+            remote_id = str(uuid.uuid4())
+        instance._remote_id = remote_id
+        _remote_tensor_registry[remote_id] = instance
+        return instance
+    
+    def __repr__(self):
+        # Only materialize when actually displaying the tensor
+        materialized = self.materialize()
+        return f"RemoteProxyTensor(id={self._remote_id}, value={materialized})"
+    
+    def materialize(self):
+        """Fetch the actual tensor data from the remote server."""
+        # Call your C++ extension to get the actual tensor data
+        # This would communicate with the remote server
+        print(f"Materializing tensor with ID: {self._remote_id}")
+        
+        # For now, this is just a placeholder
+        # In reality, you'd call into your C++ code to fetch the data
+        result = torch.zeros_like(self, device="cpu")
+        return result
+    
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+            
+        # Check if this operation requires materialization
+        if func.__name__ in ['copy_', 'print', 'to_string']:
+            # Materialize all remote tensors in args
+            new_args = []
+            for arg in args:
+                if isinstance(arg, RemoteProxyTensor):
+                    new_args.append(arg.materialize())
+                else:
+                    new_args.append(arg)
+            result = func(*new_args, **kwargs)
+            return result
+        
+        # Otherwise, execute the operation remotely and return a new proxy
+        print(f"Executing {func.__name__} remotely")
+        
+        # For non-materializing operations, just create a new proxy tensor
+        # that represents the result of the operation
+        result_tensor = func(*args, **kwargs)
+        return RemoteProxyTensor(result_tensor, remote_id=str(uuid.uuid4()))
+    
+    
+# Modify your existing code to use the proxy tensor
+def empty(*size, dtype=None, layout=torch.strided, device=None, requires_grad=False):
+    """Create a remote proxy tensor with uninitialized data."""
+    if device is None or device.type != "privateuseone":
+        raise ValueError("Device must be remote_cuda (privateuseone)")
+    
+    # Create a metadata-only tensor on CPU first
+    cpu_tensor = torch.empty(*size, dtype=dtype, layout=layout, device="cpu", 
+                            requires_grad=requires_grad)
+    
+    # Generate a remote ID
+    remote_id = str(uuid.uuid4())
+    
+    # Register an empty tensor on the remote server
+    # This would call into your C++ extension
+    # _ext.register_remote_tensor(remote_id, size, dtype, layout)
+    
+    # Return a proxy that points to the remote tensor
+    return RemoteProxyTensor(cpu_tensor.to(device), remote_id)
+

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -26,3 +26,13 @@ py_test(
     imports = [".."],
 )
 
+py_test(
+    name = "test_proxy",
+    srcs = ["test_proxy.py"],
+    deps = [
+        "//:remote_cuda",
+        requirement("torch"),
+	requirement("numpy"),
+    ],
+)
+

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,17 @@
+import torch
+from remote_cuda import remote_cuda, RemoteProxyTensor
+
+def test_handle_empty_strided():
+    print("[TEST] Calling remote_cuda.empty() on privateuseone")
+
+    tensor = remote_cuda.empty(2, 2, device=torch.device("privateuseone"))
+    
+    # print("[INFO] Returned tensor:", tensor)
+    print("[INFO] Type:", type(tensor))
+    assert isinstance(tensor, RemoteProxyTensor)
+
+    print("[PASS] handle_empty_strided() was called and returned RemoteProxyTensor")
+
+if __name__ == "__main__":
+    test_handle_empty_strided()
+


### PR DESCRIPTION
When empty is called, a pair of remote_id and tensor is generated in remote_dispatch.cc and can be looked up. RemoteProxyTensor get the remote_id. And a proxy tensor is returned.
